### PR TITLE
Fixed the bug for issue 2.  Better names

### DIFF
--- a/models/pointnet2_msg_cls.py
+++ b/models/pointnet2_msg_cls.py
@@ -20,13 +20,7 @@ def model_fn_decorator(criterion):
         inputs = Variable(inputs.cuda(async=True), volatile=eval)
         labels = Variable(labels.cuda(async=True), volatile=eval)
 
-        xyz = inputs[..., :3]
-        if inputs.size(2) > 3:
-            points = inputs[..., 3:]
-        else:
-            points = None
-
-        preds = model(xyz, points)
+        preds = model(inputs)
         labels = labels.view(-1)
         loss = criterion(preds, labels)
 
@@ -39,6 +33,20 @@ def model_fn_decorator(criterion):
 
 
 class Pointnet2MSG(nn.Module):
+    r"""
+        PointNet2 with multi-scale grouping
+        Classification network
+
+        Parameters
+        ----------
+        num_classes: int
+            Number of semantics classes to predict over -- size of softmax classifier
+        input_channels: int = 3
+            Number of input channels in the feature descriptor for each point.  If the point cloud is Nx9, this
+            value should be 6 as in an Nx9 point cloud, 3 of the channels are xyz, and 6 are feature descriptors
+        use_xyz: bool = True
+            Whether or not to use the xyz position of a point as a feature
+    """
 
     def __init__(self, num_classes, input_channels=3, use_xyz=True):
         super().__init__()
@@ -63,11 +71,12 @@ class Pointnet2MSG(nn.Module):
                 nsamples=[16, 32, 64],
                 mlps=[[input_channels, 128], [input_channels, 256],
                       [input_channels, 256]],
+                use_xyz=use_xyz
             )
         )
         self.SA_modules.append(
             PointnetSAModule(
-                mlp=[128 + 256 + 256, 256, 512, 1024],
+                mlp=[128 + 256 + 256, 256, 512, 1024], use_xyz=use_xyz
             )
         )
 
@@ -79,15 +88,33 @@ class Pointnet2MSG(nn.Module):
             pt_utils.FC(256, num_classes, activation=None)
         )
 
-    def forward(self, xyz, points=None):
-        xyz = xyz.contiguous()
-        points = (
-            points.transpose(1, 2).contiguous() if points is not None else None
+    def _break_up_pc(self, pc):
+        xyz = pc[..., 0:3].contiguous()
+        features = (
+            pc[..., 3:].transpose(1, 2).contiguous()
+            if pc.size(-1) > 3 else None
         )
-        for module in self.SA_modules:
-            xyz, points = module(xyz, points)
 
-        return self.FC_layer(points.squeeze(-1))
+        return xyz, features
+
+    def forward(self, pointcloud: torch.cuda.FloatTensor):
+        r"""
+            Forward pass of the network
+
+            Parameters
+            ----------
+            pointcloud: Variable(torch.cuda.FloatTensor)
+                (B, N, 3 + input_channels) tensor
+                Point cloud to run predicts on
+                Each point in the point-cloud MUST
+                be formated as (x, y, z, features...)
+        """
+        xyz, features = self._break_up_pc(pointcloud)
+
+        for module in self.SA_modules:
+            xyz, features = module(xyz, features)
+
+        return self.FC_layer(features.squeeze(-1))
 
 
 if __name__ == "__main__":
@@ -99,13 +126,14 @@ if __name__ == "__main__":
     N = 2048
     inputs = torch.randn(B, N, 6).cuda()
     labels = torch.from_numpy(np.random.randint(0, 3, size=B)).cuda()
-    model = Pointnet2MSG(3, input_channels=3)
+    model = Pointnet2MSG(3, input_channels=3, use_xyz=True)
     model.cuda()
 
     optimizer = optim.Adam(model.parameters(), lr=1e-2)
 
+    print("testing with xyz")
     model_fn = model_fn_decorator(nn.CrossEntropyLoss())
-    for _ in range(20):
+    for _ in range(5):
         optimizer.zero_grad()
         _, loss, _ = model_fn(model, (inputs, labels))
         loss.backward()
@@ -113,15 +141,16 @@ if __name__ == "__main__":
         optimizer.step()
 
     # With with use_xyz=False
-    inputs = torch.randn(B, N, 3).cuda()
+    inputs = torch.randn(B, N, 6).cuda()
     labels = torch.from_numpy(np.random.randint(0, 3, size=B)).cuda()
     model = Pointnet2MSG(3, input_channels=3, use_xyz=False)
     model.cuda()
 
     optimizer = optim.Adam(model.parameters(), lr=1e-2)
 
+    print("testing without xyz")
     model_fn = model_fn_decorator(nn.CrossEntropyLoss())
-    for _ in range(20):
+    for _ in range(5):
         optimizer.zero_grad()
         _, loss, _ = model_fn(model, (inputs, labels))
         loss.backward()

--- a/models/pointnet2_msg_sem.py
+++ b/models/pointnet2_msg_sem.py
@@ -20,13 +20,7 @@ def model_fn_decorator(criterion):
         inputs = Variable(inputs.cuda(async=True), volatile=eval)
         labels = Variable(labels.cuda(async=True), volatile=eval)
 
-        xyz = inputs[..., :3]
-        if inputs.size(2) > 3:
-            points = inputs[..., 3:]
-        else:
-            points = None
-
-        preds = model(xyz, points)
+        preds = model(inputs)
         loss = criterion(preds.view(labels.numel(), -1), labels.view(-1))
 
         _, classes = torch.max(preds.data, 2)
@@ -38,8 +32,22 @@ def model_fn_decorator(criterion):
 
 
 class Pointnet2MSG(nn.Module):
+    r"""
+        PointNet2 with multi-scale grouping
+        Semantic segmentation network that uses feature propogation layers
 
-    def __init__(self, num_classes, input_channels=9, use_xyz=True):
+        Parameters
+        ----------
+        num_classes: int
+            Number of semantics classes to predict over -- size of softmax classifier that run for each point
+        input_channels: int = 6
+            Number of input channels in the feature descriptor for each point.  If the point cloud is Nx9, this
+            value should be 6 as in an Nx9 point cloud, 3 of the channels are xyz, and 6 are feature descriptors
+        use_xyz: bool = True
+            Whether or not to use the xyz position of a point as a feature
+    """
+
+    def __init__(self, num_classes, input_channels=6, use_xyz=True):
         super().__init__()
 
         self.SA_modules = nn.ModuleList()
@@ -62,6 +70,7 @@ class Pointnet2MSG(nn.Module):
                 radii=[0.1, 0.2],
                 nsamples=[16, 32],
                 mlps=[[c_in, 64, 64, 128], [c_in, 64, 96, 128]],
+                use_xyz=use_xyz
             )
         )
         c_out_1 = 128 + 128
@@ -73,6 +82,7 @@ class Pointnet2MSG(nn.Module):
                 radii=[0.2, 0.4],
                 nsamples=[16, 32],
                 mlps=[[c_in, 128, 196, 256], [c_in, 128, 196, 256]],
+                use_xyz=use_xyz
             )
         )
         c_out_2 = 256 + 256
@@ -84,13 +94,14 @@ class Pointnet2MSG(nn.Module):
                 radii=[0.4, 0.8],
                 nsamples=[16, 32],
                 mlps=[[c_in, 256, 256, 512], [c_in, 256, 384, 512]],
+                use_xyz=use_xyz
             )
         )
         c_out_3 = 512 + 512
 
         self.FP_modules = nn.ModuleList()
         self.FP_modules.append(
-            PointnetFPModule(mlp=[256 + (input_channels if use_xyz else 0), 128, 128])
+            PointnetFPModule(mlp=[256 + input_channels, 128, 128])
         )
         self.FP_modules.append(PointnetFPModule(mlp=[512 + c_out_0, 256, 256]))
         self.FP_modules.append(PointnetFPModule(mlp=[512 + c_out_1, 512, 512]))
@@ -103,24 +114,41 @@ class Pointnet2MSG(nn.Module):
             pt_utils.Conv1d(128, num_classes, activation=None)
         )
 
-    def forward(self, xyz, points=None):
-        xyz = xyz.contiguous()
-        points = (
-            points.transpose(1, 2).contiguous() if points is not None else None
+    def _break_up_pc(self, pc):
+        xyz = pc[..., 0:3].contiguous()
+        features = (
+            pc[..., 3:].transpose(1, 2).contiguous()
+            if pc.size(-1) > 3 else None
         )
 
-        l_xyz, l_points = [xyz], [points]
+        return xyz, features
+
+    def forward(self, pointcloud: torch.cuda.FloatTensor):
+        r"""
+            Forward pass of the network
+
+            Parameters
+            ----------
+            pointcloud: Variable(torch.cuda.FloatTensor)
+                (B, N, 3 + input_channels) tensor
+                Point cloud to run predicts on
+                Each point in the point-cloud MUST
+                be formated as (x, y, z, features...)
+        """
+        xyz, features = self._break_up_pc(pointcloud)
+
+        l_xyz, l_features = [xyz], [features]
         for i in range(len(self.SA_modules)):
-            li_xyz, li_points = self.SA_modules[i](l_xyz[i], l_points[i])
+            li_xyz, li_features = self.SA_modules[i](l_xyz[i], l_features[i])
             l_xyz.append(li_xyz)
-            l_points.append(li_points)
+            l_features.append(li_features)
 
         for i in range(-1, -(len(self.FP_modules) + 1), -1):
-            l_points[i - 1] = self.FP_modules[i](
-                l_xyz[i - 1], l_xyz[i], l_points[i - 1], l_points[i]
+            l_features[i - 1] = self.FP_modules[i](
+                l_xyz[i - 1], l_xyz[i], l_features[i - 1], l_features[i]
             )
 
-        return self.FC_layer(l_points[0]).transpose(1, 2).contiguous()
+        return self.FC_layer(l_features[0]).transpose(1, 2).contiguous()
 
 
 if __name__ == "__main__":
@@ -137,8 +165,9 @@ if __name__ == "__main__":
 
     optimizer = optim.Adam(model.parameters(), lr=1e-2)
 
+    print("Testing with xyz")
     model_fn = model_fn_decorator(nn.CrossEntropyLoss())
-    for _ in range(20):
+    for _ in range(5):
         optimizer.zero_grad()
         _, loss, _ = model_fn(model, (inputs, labels))
         loss.backward()
@@ -146,7 +175,7 @@ if __name__ == "__main__":
         optimizer.step()
 
     # with use_xyz=False
-    inputs = torch.randn(B, N, 3).cuda()
+    inputs = torch.randn(B, N, 6).cuda()
     labels = torch.from_numpy(np.random.randint(0, 3,
                                                 size=B * N)).view(B, N).cuda()
     model = Pointnet2MSG(3, input_channels=3, use_xyz=False)
@@ -154,8 +183,9 @@ if __name__ == "__main__":
 
     optimizer = optim.Adam(model.parameters(), lr=1e-2)
 
+    print("Testing without xyz")
     model_fn = model_fn_decorator(nn.CrossEntropyLoss())
-    for _ in range(20):
+    for _ in range(5):
         optimizer.zero_grad()
         _, loss, _ = model_fn(model, (inputs, labels))
         loss.backward()

--- a/models/pointnet2_ssg_sem.py
+++ b/models/pointnet2_ssg_sem.py
@@ -20,13 +20,7 @@ def model_fn_decorator(criterion):
         inputs = Variable(inputs.cuda(async=True), volatile=eval)
         labels = Variable(labels.cuda(async=True), volatile=eval)
 
-        xyz = inputs[..., :3]
-        if inputs.size(2) > 3:
-            points = inputs[..., 3:]
-        else:
-            points = None
-
-        preds = model(xyz, points)
+        preds = model(inputs)
         loss = criterion(preds.view(labels.numel(), -1), labels.view(-1))
 
         _, classes = torch.max(preds.data, 2)
@@ -38,6 +32,20 @@ def model_fn_decorator(criterion):
 
 
 class Pointnet2SSG(nn.Module):
+    r"""
+        PointNet2 with single-scale grouping
+        Semantic segmentation network that uses feature propogation layers
+
+        Parameters
+        ----------
+        num_classes: int
+            Number of semantics classes to predict over -- size of softmax classifier that run for each point
+        input_channels: int = 6
+            Number of input channels in the feature descriptor for each point.  If the point cloud is Nx9, this
+            value should be 6 as in an Nx9 point cloud, 3 of the channels are xyz, and 6 are feature descriptors
+        use_xyz: bool = True
+            Whether or not to use the xyz position of a point as a feature
+    """
 
     def __init__(self, num_classes, input_channels=3, use_xyz=True):
         super().__init__()
@@ -54,23 +62,35 @@ class Pointnet2SSG(nn.Module):
         )
         self.SA_modules.append(
             PointnetSAModule(
-                npoint=256, radius=0.2, nsample=32, mlp=[64, 64, 64, 128]
+                npoint=256,
+                radius=0.2,
+                nsample=32,
+                mlp=[64, 64, 64, 128],
+                use_xyz=use_xyz
             )
         )
         self.SA_modules.append(
             PointnetSAModule(
-                npoint=64, radius=0.4, nsample=32, mlp=[128, 128, 128, 256]
+                npoint=64,
+                radius=0.4,
+                nsample=32,
+                mlp=[128, 128, 128, 256],
+                use_xyz=use_xyz
             )
         )
         self.SA_modules.append(
             PointnetSAModule(
-                npoint=16, radius=0.8, nsample=32, mlp=[256, 256, 256, 512]
+                npoint=16,
+                radius=0.8,
+                nsample=32,
+                mlp=[256, 256, 256, 512],
+                use_xyz=use_xyz
             )
         )
 
         self.FP_modules = nn.ModuleList()
         self.FP_modules.append(
-            PointnetFPModule(mlp=[128 + (input_channels if use_xyz else 0), 128, 128, 128])
+            PointnetFPModule(mlp=[128 + input_channels, 128, 128, 128])
         )
         self.FP_modules.append(PointnetFPModule(mlp=[256 + 64, 256, 128]))
         self.FP_modules.append(PointnetFPModule(mlp=[256 + 128, 256, 256]))
@@ -81,24 +101,41 @@ class Pointnet2SSG(nn.Module):
             pt_utils.Conv1d(128, num_classes, activation=None)
         )
 
-    def forward(self, xyz, points=None):
-        xyz = xyz.contiguous()
-        points = (
-            points.transpose(1, 2).contiguous() if points is not None else None
+    def _break_up_pc(self, pc):
+        xyz = pc[..., 0:3].contiguous()
+        features = (
+            pc[..., 3:].transpose(1, 2).contiguous()
+            if pc.size(-1) > 3 else None
         )
 
-        l_xyz, l_points = [xyz], [points]
+        return xyz, features
+
+    def forward(self, pointcloud: torch.cuda.FloatTensor):
+        r"""
+            Forward pass of the network
+
+            Parameters
+            ----------
+            pointcloud: Variable(torch.cuda.FloatTensor)
+                (B, N, 3 + input_channels) tensor
+                Point cloud to run predicts on
+                Each point in the point-cloud MUST
+                be formated as (x, y, z, features...)
+        """
+        xyz, features = self._break_up_pc(pointcloud)
+
+        l_xyz, l_features = [xyz], [features]
         for i in range(len(self.SA_modules)):
-            li_xyz, li_points = self.SA_modules[i](l_xyz[i], l_points[i])
+            li_xyz, li_features = self.SA_modules[i](l_xyz[i], l_features[i])
             l_xyz.append(li_xyz)
-            l_points.append(li_points)
+            l_features.append(li_features)
 
         for i in range(-1, -(len(self.FP_modules) + 1), -1):
-            l_points[i - 1] = self.FP_modules[i](
-                l_xyz[i - 1], l_xyz[i], l_points[i - 1], l_points[i]
+            l_features[i - 1] = self.FP_modules[i](
+                l_xyz[i - 1], l_xyz[i], l_features[i - 1], l_features[i]
             )
 
-        return self.FC_layer(l_points[0]).transpose(1, 2).contiguous()
+        return self.FC_layer(l_features[0]).transpose(1, 2).contiguous()
 
 
 if __name__ == "__main__":
@@ -115,17 +152,17 @@ if __name__ == "__main__":
 
     optimizer = optim.Adam(model.parameters(), lr=1e-2)
 
+    print("Testing with xyz")
     model_fn = model_fn_decorator(nn.CrossEntropyLoss())
-    for _ in range(20):
+    for _ in range(5):
         optimizer.zero_grad()
         _, loss, _ = model_fn(model, (inputs, labels))
         loss.backward()
         print(loss.data[0])
         optimizer.step()
 
-
     # try with use_xyz=False too
-    inputs = torch.randn(B, N, 3).cuda()
+    inputs = torch.randn(B, N, 6).cuda()
     labels = torch.from_numpy(np.random.randint(0, 3,
                                                 size=B * N)).view(B, N).cuda()
     model = Pointnet2SSG(3, input_channels=3, use_xyz=False)
@@ -133,9 +170,9 @@ if __name__ == "__main__":
 
     optimizer = optim.Adam(model.parameters(), lr=1e-2)
 
+    print("Testing without xyz")
     model_fn = model_fn_decorator(nn.CrossEntropyLoss())
-
-    for _ in range(20):
+    for _ in range(5):
         optimizer.zero_grad()
         _, loss, _ = model_fn(model, (inputs, labels))
         loss.backward()

--- a/train_cls.py
+++ b/train_cls.py
@@ -115,7 +115,7 @@ if __name__ == "__main__":
 
     tb_log.configure('runs/{}'.format(args.run_name))
 
-    model = Pointnet(input_channels=3, num_classes=40, use_xyz=False)
+    model = Pointnet(input_channels=0, num_classes=40, use_xyz=True)
     model.cuda()
     optimizer = optim.Adam(
         model.parameters(), lr=args.lr, weight_decay=args.weight_decay

--- a/train_sem_seg.py
+++ b/train_sem_seg.py
@@ -104,7 +104,7 @@ if __name__ == "__main__":
         shuffle=True
     )
 
-    model = Pointnet(num_classes=13, use_xyz=False)
+    model = Pointnet(num_classes=13, use_xyz=True)
     model.cuda()
     optimizer = optim.Adam(
         model.parameters(), lr=args.lr, weight_decay=args.weight_decay


### PR DESCRIPTION
I have added doc strings to the models

I also clarified what `use_xyz` means.  The original PointNet++ implementation uses `points` to mean the feature descriptors of the points in the point cloud, and uses `xyz` for their xyz position.  This leads to obvious confusing.  I have renamed most of the outward facing API to `xyz` to mean the a point's xyz position and `features` to mean it's feature descriptor.  Hopefully this will reduce confusion!

This means that point clouds are an `(N, (3 + channels))` matrix and each point must be `(x, y, z, features...)`