### PR TITLE
Bug in ModelNet40Loader is fixed

### DIFF
--- a/pointnet2/data/ModelNet40Loader.py
+++ b/pointnet2/data/ModelNet40Loader.py
@@ -87,7 +87,7 @@ class ModelNet40Cls(data.Dataset):
         self.actual_number_of_points = pts
 
     def randomize(self):
-        pass
+        self.actual_number_of_points = min(self.num_points,self.points.shape[1])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When running **python -m pointnet2.train.train_cls**  , the following bug will happen.

File "./pointnet2/data/ModelNet40Loader.py", line 71, in __getitem__
    pt_idxs = np.arange(0, self.actual_number_of_points)
AttributeError: 'ModelNet40Cls' object has no attribute 'actual_number_of_points'

The bug is fixed in this pull request.