### PR TITLE
Fix bug: change the parameter name in PointNet2ClassificationSSG

### DIFF
--- a/pointnet2/models/pointnet2_ssg_cls.py
+++ b/pointnet2/models/pointnet2_ssg_cls.py
@@ -53,10 +53,10 @@ bnm_clip = 1e-2
 
 
 class PointNet2ClassificationSSG(pl.LightningModule):
-    def __init__(self, args):
+    def __init__(self, hparams):
         super().__init__()
 
-        self.hparams = args
+        self.hparams = hparams
 
         self._build_model()
 


### PR DESCRIPTION
Change the parameter name in PointNet2ClassificationSSG.__init__ from 'args' to 'hparams' so that users can use LightningModule.load_from_checkpoint to load the checkpoints like this:
```python
import hydra

model_path = 'path/to/checkpoint'

@hydra.main("config/config.yaml")
def main(cfg):
    model = hydra.utils.instantiate(cfg.task_model, cfg)
    model.load_from_checkpoint(model_path)


if __name__ == "__main__":
    main()
```
